### PR TITLE
Implement kid support to tokens

### DIFF
--- a/auth/access-token.go
+++ b/auth/access-token.go
@@ -25,3 +25,13 @@ func CreateAccessToken(p mjwt.Signer, sub, id string, aud jwt.ClaimStrings, perm
 func CreateAccessTokenWithDuration(p mjwt.Signer, dur time.Duration, sub, id string, aud jwt.ClaimStrings, perms *claims.PermStorage) (string, error) {
 	return p.GenerateJwt(sub, id, aud, dur, &AccessTokenClaims{Perms: perms})
 }
+
+// CreateAccessTokenWithKID creates an access token with the default 15 minute duration and the specified kID
+func CreateAccessTokenWithKID(p mjwt.Signer, sub, id string, aud jwt.ClaimStrings, perms *claims.PermStorage, kID string) (string, error) {
+	return CreateAccessTokenWithDurationAndKID(p, time.Minute*15, sub, id, aud, perms, kID)
+}
+
+// CreateAccessTokenWithDurationAndKID creates an access token with a custom duration and the specified kID
+func CreateAccessTokenWithDurationAndKID(p mjwt.Signer, dur time.Duration, sub, id string, aud jwt.ClaimStrings, perms *claims.PermStorage, kID string) (string, error) {
+	return p.GenerateJwtWithKID(sub, id, aud, dur, &AccessTokenClaims{Perms: perms}, kID)
+}

--- a/auth/access-token_test.go
+++ b/auth/access-token_test.go
@@ -31,3 +31,29 @@ func TestCreateAccessToken(t *testing.T) {
 	assert.True(t, b.Claims.Perms.Has("mjwt:test2"))
 	assert.False(t, b.Claims.Perms.Has("mjwt:test3"))
 }
+
+func TestCreateAccessTokenInvalid(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+
+	kStore := mjwt.NewMJwtKeyStore()
+	kStore.SetKey("test", key)
+
+	ps := claims.NewPermStorage()
+	ps.Set("mjwt:test")
+	ps.Set("mjwt:test2")
+
+	s := mjwt.NewMJwtSignerWithKeyStore("mjwt.test", nil, kStore)
+
+	accessToken, err := CreateAccessTokenWithKID(s, "1", "test", nil, ps, "test")
+	assert.NoError(t, err)
+
+	_, b, err := mjwt.ExtractClaims[AccessTokenClaims](s, accessToken)
+	assert.NoError(t, err)
+	assert.Equal(t, "1", b.Subject)
+	assert.Equal(t, "test", b.ID)
+	assert.True(t, b.Claims.Perms.Has("mjwt:test"))
+	assert.True(t, b.Claims.Perms.Has("mjwt:test2"))
+	assert.False(t, b.Claims.Perms.Has("mjwt:test3"))
+}

--- a/auth/pair.go
+++ b/auth/pair.go
@@ -26,3 +26,23 @@ func CreateTokenPairWithDuration(p mjwt.Signer, accessDur, refreshDur time.Durat
 	}
 	return accessToken, refreshToken, nil
 }
+
+// CreateTokenPairWithKID creates an access and refresh token pair using the default
+// 15 minute and 7 day durations respectively using the specified kID
+func CreateTokenPairWithKID(p mjwt.Signer, sub, id, rId string, aud, rAud jwt.ClaimStrings, perms *claims.PermStorage, kID string) (string, string, error) {
+	return CreateTokenPairWithDurationAndKID(p, time.Minute*15, time.Hour*24*7, sub, id, rId, aud, rAud, perms, kID)
+}
+
+// CreateTokenPairWithDurationAndKID creates an access and refresh token pair using
+// custom durations for the access and refresh tokens
+func CreateTokenPairWithDurationAndKID(p mjwt.Signer, accessDur, refreshDur time.Duration, sub, id, rId string, aud, rAud jwt.ClaimStrings, perms *claims.PermStorage, kID string) (string, string, error) {
+	accessToken, err := CreateAccessTokenWithDurationAndKID(p, accessDur, sub, id, aud, perms, kID)
+	if err != nil {
+		return "", "", err
+	}
+	refreshToken, err := CreateRefreshTokenWithDurationAndKID(p, refreshDur, sub, rId, id, rAud, kID)
+	if err != nil {
+		return "", "", err
+	}
+	return accessToken, refreshToken, nil
+}

--- a/auth/pair_test.go
+++ b/auth/pair_test.go
@@ -36,3 +36,34 @@ func TestCreateTokenPair(t *testing.T) {
 	assert.Equal(t, "1", b2.Subject)
 	assert.Equal(t, "test2", b2.ID)
 }
+
+func TestCreateTokenPairWithKID(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+
+	kStore := mjwt.NewMJwtKeyStore()
+	kStore.SetKey("test", key)
+
+	ps := claims.NewPermStorage()
+	ps.Set("mjwt:test")
+	ps.Set("mjwt:test2")
+
+	s := mjwt.NewMJwtSignerWithKeyStore("mjwt.test", nil, kStore)
+
+	accessToken, refreshToken, err := CreateTokenPairWithKID(s, "1", "test", "test2", nil, nil, ps, "test")
+	assert.NoError(t, err)
+
+	_, b, err := mjwt.ExtractClaims[AccessTokenClaims](s, accessToken)
+	assert.NoError(t, err)
+	assert.Equal(t, "1", b.Subject)
+	assert.Equal(t, "test", b.ID)
+	assert.True(t, b.Claims.Perms.Has("mjwt:test"))
+	assert.True(t, b.Claims.Perms.Has("mjwt:test2"))
+	assert.False(t, b.Claims.Perms.Has("mjwt:test3"))
+
+	_, b2, err := mjwt.ExtractClaims[RefreshTokenClaims](s, refreshToken)
+	assert.NoError(t, err)
+	assert.Equal(t, "1", b2.Subject)
+	assert.Equal(t, "test2", b2.ID)
+}

--- a/auth/refresh-token.go
+++ b/auth/refresh-token.go
@@ -24,3 +24,13 @@ func CreateRefreshToken(p mjwt.Signer, sub, id, ati string, aud jwt.ClaimStrings
 func CreateRefreshTokenWithDuration(p mjwt.Signer, dur time.Duration, sub, id, ati string, aud jwt.ClaimStrings) (string, error) {
 	return p.GenerateJwt(sub, id, aud, dur, RefreshTokenClaims{AccessTokenId: ati})
 }
+
+// CreateRefreshTokenWithKID creates a refresh token with the default 7 day duration and the specified kID
+func CreateRefreshTokenWithKID(p mjwt.Signer, sub, id, ati string, aud jwt.ClaimStrings, kID string) (string, error) {
+	return CreateRefreshTokenWithDurationAndKID(p, time.Hour*24*7, sub, id, ati, aud, kID)
+}
+
+// CreateRefreshTokenWithDurationAndKID creates a refresh token with a custom duration and the specified kID
+func CreateRefreshTokenWithDurationAndKID(p mjwt.Signer, dur time.Duration, sub, id, ati string, aud jwt.ClaimStrings, kID string) (string, error) {
+	return p.GenerateJwtWithKID(sub, id, aud, dur, RefreshTokenClaims{AccessTokenId: ati}, kID)
+}

--- a/auth/refresh-token_test.go
+++ b/auth/refresh-token_test.go
@@ -24,3 +24,23 @@ func TestCreateRefreshToken(t *testing.T) {
 	assert.Equal(t, "test", b.ID)
 	assert.Equal(t, "test2", b.Claims.AccessTokenId)
 }
+
+func TestCreateRefreshTokenWithKID(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+
+	kStore := mjwt.NewMJwtKeyStore()
+	kStore.SetKey("test", key)
+
+	s := mjwt.NewMJwtSignerWithKeyStore("mjwt.test", nil, kStore)
+
+	refreshToken, err := CreateRefreshTokenWithKID(s, "1", "test", "test2", nil, "test")
+	assert.NoError(t, err)
+
+	_, b, err := mjwt.ExtractClaims[RefreshTokenClaims](s, refreshToken)
+	assert.NoError(t, err)
+	assert.Equal(t, "1", b.Subject)
+	assert.Equal(t, "test", b.ID)
+	assert.Equal(t, "test2", b.Claims.AccessTokenId)
+}

--- a/cmd/mjwt/access.go
+++ b/cmd/mjwt/access.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"context"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"flag"
 	"fmt"
 	"github.com/1f349/mjwt"
 	"github.com/1f349/mjwt/auth"
 	"github.com/1f349/mjwt/claims"
+	"github.com/1f349/rsa-helper/rsaprivate"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/google/subcommands"
 	"os"
@@ -46,7 +44,7 @@ func (s *accessCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	}
 
 	args := f.Args()
-	key, err := s.parseKey(args[0])
+	key, err := rsaprivate.Read(args[0])
 	if err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, "Error: Failed to parse private key: ", err)
 		return subcommands.ExitFailure
@@ -76,14 +74,4 @@ func (s *accessCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 
 	fmt.Println(token)
 	return subcommands.ExitSuccess
-}
-
-func (s *accessCmd) parseKey(privKeyFile string) (*rsa.PrivateKey, error) {
-	b, err := os.ReadFile(privKeyFile)
-	if err != nil {
-		return nil, err
-	}
-
-	p, _ := pem.Decode(b)
-	return x509.ParsePKCS1PrivateKey(p.Bytes)
 }

--- a/cmd/mjwt/access.go
+++ b/cmd/mjwt/access.go
@@ -67,7 +67,7 @@ func (s *accessCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}
 	}
 
 	var token string
-	if len(s.kID) == 1 && s.kID[0] == '\x00' {
+	if s.kID == "\x00" {
 		signer := mjwt.NewMJwtSigner(s.issuer, key)
 		token, err = signer.GenerateJwt(s.subject, s.id, aud, dur, auth.AccessTokenClaims{Perms: ps})
 	} else {

--- a/cmd/mjwt/gen.go
+++ b/cmd/mjwt/gen.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"flag"
 	"fmt"
+	"github.com/1f349/rsa-helper/rsaprivate"
+	"github.com/1f349/rsa-helper/rsapublic"
 	"github.com/google/subcommands"
 	"math/rand"
 	"os"
@@ -49,29 +49,14 @@ func (g *genCmd) Execute(_ context.Context, f *flag.FlagSet, _ ...interface{}) s
 }
 
 func (g *genCmd) gen(privPath, pubPath string) error {
-	createPriv, err := os.OpenFile(privPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return err
-	}
-	defer createPriv.Close()
-
-	createPub, err := os.OpenFile(pubPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
-	if err != nil {
-		return err
-	}
-	defer createPub.Close()
-
 	key, err := rsa.GenerateKey(rand.New(rand.NewSource(time.Now().UnixNano())), g.bits)
 	if err != nil {
 		return err
 	}
 
-	keyBytes := x509.MarshalPKCS1PrivateKey(key)
-	pubBytes := x509.MarshalPKCS1PublicKey(&key.PublicKey)
-	err = pem.Encode(createPriv, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: keyBytes})
+	err = rsaprivate.Write(privPath, key)
 	if err != nil {
 		return err
 	}
-	err = pem.Encode(createPub, &pem.Block{Type: "RSA PUBLIC KEY", Bytes: pubBytes})
-	return err
+	return rsapublic.Write(pubPath, &key.PublicKey)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,11 @@
 module github.com/1f349/mjwt
 
-go 1.19
+go 1.22
+
+toolchain go1.22.3
 
 require (
+	github.com/1f349/rsa-helper v0.0.0-20240608023351-e4382c728b17
 	github.com/becheran/wildmatch-go v1.0.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/subcommands v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22
 toolchain go1.22.3
 
 require (
-	github.com/1f349/rsa-helper v0.0.0-20240608023351-e4382c728b17
+	github.com/1f349/rsa-helper v0.0.1
 	github.com/becheran/wildmatch-go v1.0.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/subcommands v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
-github.com/1f349/rsa-helper v0.0.0-20240608023351-e4382c728b17 h1:cgJDS14TTM8hvg1qNhXFj3IfFEZ99IXR00D8gcwbY98=
-github.com/1f349/rsa-helper v0.0.0-20240608023351-e4382c728b17/go.mod h1:VUQ++1tYYhYrXeOmVFkQ82BegR24HQEJHl5lHbjg7yg=
+github.com/1f349/rsa-helper v0.0.1 h1:Ec/MXHR2eIpLgIR69eqhCV2o8OOBs2JZNAkEhW7HQks=
 github.com/1f349/rsa-helper v0.0.1/go.mod h1:VUQ++1tYYhYrXeOmVFkQ82BegR24HQEJHl5lHbjg7yg=
 github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2PZFSzA=
 github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/1f349/rsa-helper v0.0.0-20240608023351-e4382c728b17 h1:cgJDS14TTM8hvg1qNhXFj3IfFEZ99IXR00D8gcwbY98=
+github.com/1f349/rsa-helper v0.0.0-20240608023351-e4382c728b17/go.mod h1:VUQ++1tYYhYrXeOmVFkQ82BegR24HQEJHl5lHbjg7yg=
 github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2PZFSzA=
 github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/1f349/rsa-helper v0.0.0-20240608023351-e4382c728b17 h1:cgJDS14TTM8hvg1qNhXFj3IfFEZ99IXR00D8gcwbY98=
 github.com/1f349/rsa-helper v0.0.0-20240608023351-e4382c728b17/go.mod h1:VUQ++1tYYhYrXeOmVFkQ82BegR24HQEJHl5lHbjg7yg=
+github.com/1f349/rsa-helper v0.0.1/go.mod h1:VUQ++1tYYhYrXeOmVFkQ82BegR24HQEJHl5lHbjg7yg=
 github.com/becheran/wildmatch-go v1.0.0 h1:mE3dGGkTmpKtT4Z+88t8RStG40yN9T+kFEGj2PZFSzA=
 github.com/becheran/wildmatch-go v1.0.0/go.mod h1:gbMvj0NtVdJ15Mg/mH9uxk2R1QCistMyU7d9KFzroX4=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/interfaces.go
+++ b/interfaces.go
@@ -21,3 +21,14 @@ type Verifier interface {
 	VerifyJwt(token string, claims baseTypeClaim) (*jwt.Token, error)
 	PublicKey() *rsa.PublicKey
 }
+
+// KeyStore is used for the kid header support in Signer and Verifier.
+type KeyStore interface {
+	SetKey(kID string, prvKey *rsa.PrivateKey) bool
+	SetKeyPublic(kID string, pubKey *rsa.PublicKey) bool
+	RemoveKey(kID string) bool
+	ListKeys() []string
+	GetKey(kID string) *rsa.PrivateKey
+	GetKeyPublic(kID string) *rsa.PublicKey
+	ClearKeys()
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -26,7 +26,7 @@ type Verifier interface {
 type KeyStore interface {
 	SetKey(kID string, prvKey *rsa.PrivateKey) bool
 	SetKeyPublic(kID string, pubKey *rsa.PublicKey) bool
-	RemoveKey(kID string) bool
+	RemoveKey(kID string)
 	ListKeys() []string
 	GetKey(kID string) *rsa.PrivateKey
 	GetKeyPublic(kID string) *rsa.PublicKey

--- a/interfaces.go
+++ b/interfaces.go
@@ -12,20 +12,25 @@ type Signer interface {
 	Verifier
 	GenerateJwt(sub, id string, aud jwt.ClaimStrings, dur time.Duration, claims Claims) (string, error)
 	SignJwt(claims jwt.Claims) (string, error)
+	GenerateJwtWithKID(sub, id string, aud jwt.ClaimStrings, dur time.Duration, claims Claims, kID string) (string, error)
+	SignJwtWithKID(claims jwt.Claims, kID string) (string, error)
 	Issuer() string
 	PrivateKey() *rsa.PrivateKey
+	PrivateKeyOf(kID string) *rsa.PrivateKey
 }
 
 // Verifier is used to verify the validity MJWT tokens and extract the claim values.
 type Verifier interface {
 	VerifyJwt(token string, claims baseTypeClaim) (*jwt.Token, error)
 	PublicKey() *rsa.PublicKey
+	PublicKeyOf(kID string) *rsa.PublicKey
+	GetKeyStore() KeyStore
 }
 
 // KeyStore is used for the kid header support in Signer and Verifier.
 type KeyStore interface {
-	SetKey(kID string, prvKey *rsa.PrivateKey) bool
-	SetKeyPublic(kID string, pubKey *rsa.PublicKey) bool
+	SetKey(kID string, prvKey *rsa.PrivateKey)
+	SetKeyPublic(kID string, pubKey *rsa.PublicKey)
 	RemoveKey(kID string)
 	ListKeys() []string
 	GetKey(kID string) *rsa.PrivateKey

--- a/key_store.go
+++ b/key_store.go
@@ -32,7 +32,7 @@ func NewMJwtKeyStore() KeyStore {
 
 // NewMJwtKeyStoreFromDirectory loads keys from a directory with the specified extensions to denote public and private
 // rsa keys; the kID is the filename of the key up to the first .
-func NewMJwtKeyStoreFromDirectory(directory string, keyPrvExt string, keyPubExt string) (KeyStore, error) {
+func NewMJwtKeyStoreFromDirectory(directory, keyPrvExt, keyPubExt string) (KeyStore, error) {
 	// Create empty KeyStore
 	ks := NewMJwtKeyStore().(*defaultMJwtKeyStore)
 	// List directory contents
@@ -78,7 +78,7 @@ func NewMJwtKeyStoreFromDirectory(directory string, keyPrvExt string, keyPubExt 
 
 // ExportKeyStore saves all the keys stored in the specified KeyStore into a directory with the specified
 // extensions for public and private keys
-func ExportKeyStore(ks KeyStore, directory string, keyPrvExt string, keyPubExt string) error {
+func ExportKeyStore(ks KeyStore, directory, keyPrvExt, keyPubExt string) error {
 	if ks == nil {
 		return errors.New("ks is nil")
 	}
@@ -110,21 +110,21 @@ func ExportKeyStore(ks KeyStore, directory string, keyPrvExt string, keyPubExt s
 }
 
 // SetKey adds a new rsa.PrivateKey with the specified kID to the KeyStore.
-func (d *defaultMJwtKeyStore) SetKey(kID string, prvKey *rsa.PrivateKey) bool {
+func (d *defaultMJwtKeyStore) SetKey(kID string, prvKey *rsa.PrivateKey) {
 	if d == nil || prvKey == nil {
-		return false
+		return
 	}
 	d.rwLocker.Lock()
 	defer d.rwLocker.Unlock()
 	d.store[kID] = prvKey
 	d.storePub[kID] = &prvKey.PublicKey
-	return true
+	return
 }
 
 // SetKeyPublic adds a new rsa.PublicKey with the specified kID to the KeyStore.
-func (d *defaultMJwtKeyStore) SetKeyPublic(kID string, pubKey *rsa.PublicKey) bool {
+func (d *defaultMJwtKeyStore) SetKeyPublic(kID string, pubKey *rsa.PublicKey) {
 	if d == nil || pubKey == nil {
-		return false
+		return
 	}
 	d.rwLocker.Lock()
 	defer d.rwLocker.Unlock()
@@ -133,7 +133,7 @@ func (d *defaultMJwtKeyStore) SetKeyPublic(kID string, pubKey *rsa.PublicKey) bo
 		d.store[kID] = nil
 	}
 	d.storePub[kID] = pubKey
-	return true
+	return
 }
 
 // RemoveKey removes a specified kID from the KeyStore.

--- a/key_store.go
+++ b/key_store.go
@@ -1,0 +1,159 @@
+package mjwt
+
+import (
+	"crypto/rsa"
+	"github.com/1f349/rsa-helper/rsaprivate"
+	"github.com/1f349/rsa-helper/rsapublic"
+	"os"
+	"path"
+	"strings"
+	"sync"
+)
+
+// defaultMJwtKeyStore implements KeyStore and stores kIDs against just rsa.PublicKey
+// or with rsa.PrivateKey instances as well.
+type defaultMJwtKeyStore struct {
+	rwLocker *sync.RWMutex
+	store    map[string]*rsa.PrivateKey
+	storePub map[string]*rsa.PublicKey
+}
+
+var _ KeyStore = &defaultMJwtKeyStore{}
+
+// NewMJwtKeyStore creates a new defaultMJwtKeyStore.
+func NewMJwtKeyStore() KeyStore {
+	return &defaultMJwtKeyStore{
+		rwLocker: new(sync.RWMutex),
+		store:    make(map[string]*rsa.PrivateKey),
+		storePub: make(map[string]*rsa.PublicKey),
+	}
+}
+
+// NewMJwtKeyStoreFromDirectory loads keys from a directory with the specified extensions to denote public and private
+// rsa keys; the kID is the filename of the key up to the first .
+func NewMJwtKeyStoreFromDirectory(directory string, keyPrvExt string, keyPubExt string) (KeyStore, error) {
+	// Create empty KeyStore
+	ks := NewMJwtKeyStore()
+	// List directory contents
+	dirEntries, err := os.ReadDir(directory)
+	if err != nil {
+		return nil, err
+	}
+	// Import keys from files, based on extension
+	for _, entry := range dirEntries {
+		if !entry.IsDir() {
+			firstDotIdx := strings.Index(entry.Name(), ".")
+			lastDotIdx := strings.LastIndex(entry.Name(), ".")
+			if firstDotIdx > 0 && lastDotIdx+1 < len(entry.Name()) {
+				if entry.Name()[lastDotIdx+1:] == keyPrvExt {
+					// Load rsa private key with the file name as the kID (Up to the first .)
+					key, err := rsaprivate.Read(path.Join(directory, entry.Name()))
+					if err == nil {
+						ks.SetKey(entry.Name()[:firstDotIdx], key)
+					}
+				} else if entry.Name()[lastDotIdx+1:] == keyPubExt {
+					// Load rsa public key with the file name as the kID (Up to the first .)
+					key, err := rsapublic.Read(path.Join(directory, entry.Name()))
+					if err == nil {
+						ks.SetKeyPublic(entry.Name()[:firstDotIdx], key)
+					}
+				}
+			}
+		}
+	}
+	return ks, nil
+}
+
+// SetKey adds a new rsa.PrivateKey with the specified kID to the KeyStore.
+func (d *defaultMJwtKeyStore) SetKey(kID string, prvKey *rsa.PrivateKey) bool {
+	if d == nil || prvKey == nil {
+		return false
+	}
+	d.rwLocker.Lock()
+	defer d.rwLocker.Unlock()
+	d.store[kID] = prvKey
+	d.storePub[kID] = &prvKey.PublicKey
+	return true
+}
+
+// SetKeyPublic adds a new rsa.PublicKey with the specified kID to the KeyStore.
+func (d *defaultMJwtKeyStore) SetKeyPublic(kID string, pubKey *rsa.PublicKey) bool {
+	if d == nil || pubKey == nil {
+		return false
+	}
+	d.rwLocker.Lock()
+	defer d.rwLocker.Unlock()
+	delete(d.store, kID)
+	d.storePub[kID] = pubKey
+	return true
+}
+
+// RemoveKey removes a specified kID from the KeyStore.
+func (d *defaultMJwtKeyStore) RemoveKey(kID string) bool {
+	if d == nil {
+		return false
+	}
+	d.rwLocker.Lock()
+	defer d.rwLocker.Unlock()
+	delete(d.store, kID)
+	delete(d.storePub, kID)
+	return true
+}
+
+// ListKeys lists the kIDs of all the keys in the KeyStore.
+func (d *defaultMJwtKeyStore) ListKeys() []string {
+	if d == nil {
+		return nil
+	}
+	d.rwLocker.RLock()
+	defer d.rwLocker.RUnlock()
+	lKeys := make([]string, len(d.store))
+	i := 0
+	for k := range d.store {
+		lKeys[i] = k
+	}
+	return lKeys
+}
+
+// GetKey gets the rsa.PrivateKey given the kID in the KeyStore or null if not found.
+func (d *defaultMJwtKeyStore) GetKey(kID string) *rsa.PrivateKey {
+	if d == nil {
+		return nil
+	}
+	d.rwLocker.RLock()
+	defer d.rwLocker.RUnlock()
+	kPrv, ok := d.store[kID]
+	if ok {
+		return kPrv
+	}
+	return nil
+}
+
+// GetKeyPublic gets the rsa.PublicKey given the kID in the KeyStore or null if not found.
+func (d *defaultMJwtKeyStore) GetKeyPublic(kID string) *rsa.PublicKey {
+	if d == nil {
+		return nil
+	}
+	d.rwLocker.RLock()
+	defer d.rwLocker.RUnlock()
+	kPub, ok := d.storePub[kID]
+	if ok {
+		return kPub
+	}
+	return nil
+}
+
+// ClearKeys removes all the stored keys in the KeyStore.
+func (d *defaultMJwtKeyStore) ClearKeys() {
+	if d == nil {
+		return
+	}
+	d.rwLocker.Lock()
+	defer d.rwLocker.Unlock()
+	for k := range d.store {
+		delete(d.store, k)
+	}
+	for k := range d.storePub {
+		delete(d.storePub, k)
+	}
+}

--- a/key_store.go
+++ b/key_store.go
@@ -50,7 +50,8 @@ func NewMJwtKeyStoreFromDirectory(directory, keyPrvExt, keyPubExt string) (KeySt
 		if kID == "" {
 			continue
 		}
-		if path.Ext(entry.Name()) == "."+keyPrvExt {
+		pExt := path.Ext(entry.Name())
+		if pExt == "."+keyPrvExt {
 			// Load rsa private key with the file name as the kID (Up to the first .)
 			key, err2 := rsaprivate.Read(path.Join(directory, entry.Name()))
 			if err2 == nil {
@@ -58,7 +59,7 @@ func NewMJwtKeyStoreFromDirectory(directory, keyPrvExt, keyPubExt string) (KeySt
 				ks.storePub[kID] = &key.PublicKey
 			}
 			errs = append(errs, err2)
-		} else if path.Ext(entry.Name()) == "."+keyPubExt {
+		} else if pExt == "."+keyPubExt {
 			// Load rsa public key with the file name as the kID (Up to the first .)
 			key, err2 := rsapublic.Read(path.Join(directory, entry.Name()))
 			if err2 == nil {
@@ -71,8 +72,7 @@ func NewMJwtKeyStoreFromDirectory(directory, keyPrvExt, keyPubExt string) (KeySt
 			errs = append(errs, err2)
 		}
 	}
-	err = errors.Join(errs...)
-	return ks, err
+	return ks, errors.Join(errs...)
 }
 
 // ExportKeyStore saves all the keys stored in the specified KeyStore into a directory with the specified
@@ -102,8 +102,7 @@ func ExportKeyStore(ks KeyStore, directory, keyPrvExt, keyPubExt string) error {
 			errs = append(errs, err2)
 		}
 	}
-	err = errors.Join(errs...)
-	return err
+	return errors.Join(errs...)
 }
 
 // SetKey adds a new rsa.PrivateKey with the specified kID to the KeyStore.

--- a/key_store.go
+++ b/key_store.go
@@ -107,7 +107,7 @@ func ExportKeyStore(ks KeyStore, directory, keyPrvExt, keyPubExt string) error {
 
 // SetKey adds a new rsa.PrivateKey with the specified kID to the KeyStore.
 func (d *defaultMJwtKeyStore) SetKey(kID string, prvKey *rsa.PrivateKey) {
-	if d == nil || prvKey == nil {
+	if prvKey == nil {
 		return
 	}
 	d.rwLocker.Lock()
@@ -119,7 +119,7 @@ func (d *defaultMJwtKeyStore) SetKey(kID string, prvKey *rsa.PrivateKey) {
 
 // SetKeyPublic adds a new rsa.PublicKey with the specified kID to the KeyStore.
 func (d *defaultMJwtKeyStore) SetKeyPublic(kID string, pubKey *rsa.PublicKey) {
-	if d == nil || pubKey == nil {
+	if pubKey == nil {
 		return
 	}
 	d.rwLocker.Lock()
@@ -134,9 +134,6 @@ func (d *defaultMJwtKeyStore) SetKeyPublic(kID string, pubKey *rsa.PublicKey) {
 
 // RemoveKey removes a specified kID from the KeyStore.
 func (d *defaultMJwtKeyStore) RemoveKey(kID string) {
-	if d == nil {
-		return
-	}
 	d.rwLocker.Lock()
 	defer d.rwLocker.Unlock()
 	delete(d.store, kID)
@@ -146,9 +143,6 @@ func (d *defaultMJwtKeyStore) RemoveKey(kID string) {
 
 // ListKeys lists the kIDs of all the keys in the KeyStore.
 func (d *defaultMJwtKeyStore) ListKeys() []string {
-	if d == nil {
-		return nil
-	}
 	d.rwLocker.RLock()
 	defer d.rwLocker.RUnlock()
 	lKeys := make([]string, len(d.store))
@@ -162,9 +156,6 @@ func (d *defaultMJwtKeyStore) ListKeys() []string {
 
 // GetKey gets the rsa.PrivateKey given the kID in the KeyStore or null if not found.
 func (d *defaultMJwtKeyStore) GetKey(kID string) *rsa.PrivateKey {
-	if d == nil {
-		return nil
-	}
 	d.rwLocker.RLock()
 	defer d.rwLocker.RUnlock()
 	kPrv, ok := d.store[kID]
@@ -176,9 +167,6 @@ func (d *defaultMJwtKeyStore) GetKey(kID string) *rsa.PrivateKey {
 
 // GetKeyPublic gets the rsa.PublicKey given the kID in the KeyStore or null if not found.
 func (d *defaultMJwtKeyStore) GetKeyPublic(kID string) *rsa.PublicKey {
-	if d == nil {
-		return nil
-	}
 	d.rwLocker.RLock()
 	defer d.rwLocker.RUnlock()
 	kPub, ok := d.storePub[kID]
@@ -190,9 +178,6 @@ func (d *defaultMJwtKeyStore) GetKeyPublic(kID string) *rsa.PublicKey {
 
 // ClearKeys removes all the stored keys in the KeyStore.
 func (d *defaultMJwtKeyStore) ClearKeys() {
-	if d == nil {
-		return
-	}
 	d.rwLocker.Lock()
 	defer d.rwLocker.Unlock()
 	clear(d.store)

--- a/key_store.go
+++ b/key_store.go
@@ -21,8 +21,8 @@ type defaultMJwtKeyStore struct {
 
 var _ KeyStore = &defaultMJwtKeyStore{}
 
-// newDefaultMJwtKeyStore creates a new defaultMJwtKeyStore.
-func newDefaultMJwtKeyStore() *defaultMJwtKeyStore {
+// NewMJwtKeyStore creates a new defaultMJwtKeyStore.
+func NewMJwtKeyStore() KeyStore {
 	return &defaultMJwtKeyStore{
 		rwLocker: new(sync.RWMutex),
 		store:    make(map[string]*rsa.PrivateKey),
@@ -30,16 +30,11 @@ func newDefaultMJwtKeyStore() *defaultMJwtKeyStore {
 	}
 }
 
-// NewMJwtKeyStore creates a new defaultMJwtKeyStore.
-func NewMJwtKeyStore() KeyStore {
-	return newDefaultMJwtKeyStore()
-}
-
 // NewMJwtKeyStoreFromDirectory loads keys from a directory with the specified extensions to denote public and private
 // rsa keys; the kID is the filename of the key up to the first .
 func NewMJwtKeyStoreFromDirectory(directory string, keyPrvExt string, keyPubExt string) (KeyStore, error) {
 	// Create empty KeyStore
-	ks := newDefaultMJwtKeyStore()
+	ks := NewMJwtKeyStore().(*defaultMJwtKeyStore)
 	// List directory contents
 	dirEntries, err := os.ReadDir(directory)
 	if err != nil {
@@ -142,15 +137,15 @@ func (d *defaultMJwtKeyStore) SetKeyPublic(kID string, pubKey *rsa.PublicKey) bo
 }
 
 // RemoveKey removes a specified kID from the KeyStore.
-func (d *defaultMJwtKeyStore) RemoveKey(kID string) bool {
+func (d *defaultMJwtKeyStore) RemoveKey(kID string) {
 	if d == nil {
-		return false
+		return
 	}
 	d.rwLocker.Lock()
 	defer d.rwLocker.Unlock()
 	delete(d.store, kID)
 	delete(d.storePub, kID)
-	return true
+	return
 }
 
 // ListKeys lists the kIDs of all the keys in the KeyStore.

--- a/key_store_test.go
+++ b/key_store_test.go
@@ -1,0 +1,47 @@
+package mjwt
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"github.com/1f349/rsa-helper/rsaprivate"
+	"github.com/1f349/rsa-helper/rsapublic"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path"
+	"testing"
+)
+
+func TestNewMJwtKeyStoreFromDirectory(t *testing.T) {
+	t.Parallel()
+	tempDir, err := os.MkdirTemp("", "this-is-a-test-dir")
+	assert.NoError(t, err)
+
+	const prvExt = "prv"
+	const pubExt = "pub"
+
+	key1, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	err = rsaprivate.Write(path.Join(tempDir, "key1.pem."+prvExt), key1)
+	assert.NoError(t, err)
+
+	key2, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	err = rsaprivate.Write(path.Join(tempDir, "key2.pem."+prvExt), key2)
+	assert.NoError(t, err)
+	err = rsapublic.Write(path.Join(tempDir, "key2.pem."+pubExt), &key2.PublicKey)
+	assert.NoError(t, err)
+
+	key3, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	err = rsapublic.Write(path.Join(tempDir, "key3.pem."+pubExt), &key3.PublicKey)
+	assert.NoError(t, err)
+
+	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, "prv", "pub")
+	assert.NoError(t, err)
+
+	assert.Len(t, kStore.ListKeys(), 3)
+	kIDsToFind := []string{"key1", "key2", "key3"}
+	for _, k := range kIDsToFind {
+		assert.Contains(t, kStore.ListKeys(), k)
+	}
+}

--- a/key_store_test.go
+++ b/key_store_test.go
@@ -11,32 +11,108 @@ import (
 	"testing"
 )
 
-func TestNewMJwtKeyStoreFromDirectory(t *testing.T) {
-	t.Parallel()
+const prvExt = "prv"
+const pubExt = "pub"
+
+func setupTestDir(t *testing.T, genKeys bool) (string, func(t *testing.T)) {
 	tempDir, err := os.MkdirTemp("", "this-is-a-test-dir")
 	assert.NoError(t, err)
 
-	const prvExt = "prv"
-	const pubExt = "pub"
+	if genKeys {
+		key1, err := rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsaprivate.Write(path.Join(tempDir, "key1.pem."+prvExt), key1)
+		assert.NoError(t, err)
 
-	key1, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(t, err)
-	err = rsaprivate.Write(path.Join(tempDir, "key1.pem."+prvExt), key1)
+		key2, err := rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsaprivate.Write(path.Join(tempDir, "key2.pem."+prvExt), key2)
+		assert.NoError(t, err)
+		err = rsapublic.Write(path.Join(tempDir, "key2.pem."+pubExt), &key2.PublicKey)
+		assert.NoError(t, err)
+
+		key3, err := rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsapublic.Write(path.Join(tempDir, "key3.pem."+pubExt), &key3.PublicKey)
+		assert.NoError(t, err)
+	}
+
+	return tempDir, func(t *testing.T) {
+		err := os.RemoveAll(tempDir)
+		assert.NoError(t, err)
+	}
+}
+
+func commonSubTests(t *testing.T, kStore KeyStore) {
+	key4, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.NoError(t, err)
 
-	key2, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(t, err)
-	err = rsaprivate.Write(path.Join(tempDir, "key2.pem."+prvExt), key2)
-	assert.NoError(t, err)
-	err = rsapublic.Write(path.Join(tempDir, "key2.pem."+pubExt), &key2.PublicKey)
+	key5, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.NoError(t, err)
 
-	key3, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(t, err)
-	err = rsapublic.Write(path.Join(tempDir, "key3.pem."+pubExt), &key3.PublicKey)
-	assert.NoError(t, err)
+	const extraKID1 = "key4"
+	const extraKID2 = "key5"
 
-	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, "prv", "pub")
+	t.Run("TestSetKey", func(t *testing.T) {
+		b := kStore.SetKey(extraKID1, key4)
+		assert.True(t, b)
+		assert.Contains(t, kStore.ListKeys(), extraKID1)
+	})
+
+	t.Run("TestSetKeyPublic", func(t *testing.T) {
+		b := kStore.SetKeyPublic(extraKID2, &key5.PublicKey)
+		assert.True(t, b)
+		assert.Contains(t, kStore.ListKeys(), extraKID2)
+	})
+
+	t.Run("TestGetKey", func(t *testing.T) {
+		oKey := kStore.GetKey(extraKID1)
+		assert.Same(t, key4, oKey)
+		pKey := kStore.GetKey(extraKID2)
+		assert.Nil(t, pKey)
+		aKey := kStore.GetKey("key1")
+		assert.NotNil(t, aKey)
+		bKey := kStore.GetKey("key2")
+		assert.NotNil(t, bKey)
+		cKey := kStore.GetKey("key3")
+		assert.Nil(t, cKey)
+	})
+
+	t.Run("TestGetKeyPublic", func(t *testing.T) {
+		oKey := kStore.GetKeyPublic(extraKID1)
+		assert.Same(t, &key4.PublicKey, oKey)
+		pKey := kStore.GetKeyPublic(extraKID2)
+		assert.Same(t, &key5.PublicKey, pKey)
+		aKey := kStore.GetKeyPublic("key1")
+		assert.NotNil(t, aKey)
+		bKey := kStore.GetKeyPublic("key2")
+		assert.NotNil(t, bKey)
+		cKey := kStore.GetKeyPublic("key3")
+		assert.NotNil(t, cKey)
+	})
+
+	t.Run("TestRemoveKey", func(t *testing.T) {
+		kStore.RemoveKey(extraKID1)
+		assert.NotContains(t, kStore.ListKeys(), extraKID1)
+		oKey1 := kStore.GetKey(extraKID1)
+		assert.Nil(t, oKey1)
+		oKey2 := kStore.GetKeyPublic(extraKID1)
+		assert.Nil(t, oKey2)
+	})
+
+	t.Run("TestClearKeys", func(t *testing.T) {
+		kStore.ClearKeys()
+		assert.Empty(t, kStore.ListKeys())
+	})
+}
+
+func TestNewMJwtKeyStoreFromDirectory(t *testing.T) {
+	t.Parallel()
+
+	tempDir, cleaner := setupTestDir(t, true)
+	defer cleaner(t)
+
+	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, prvExt, pubExt)
 	assert.NoError(t, err)
 
 	assert.Len(t, kStore.ListKeys(), 3)
@@ -44,4 +120,35 @@ func TestNewMJwtKeyStoreFromDirectory(t *testing.T) {
 	for _, k := range kIDsToFind {
 		assert.Contains(t, kStore.ListKeys(), k)
 	}
+
+	commonSubTests(t, kStore)
+}
+
+func TestExportKeyStore(t *testing.T) {
+	t.Parallel()
+
+	tempDir, cleaner := setupTestDir(t, true)
+	defer cleaner(t)
+	tempDir2, cleaner2 := setupTestDir(t, false)
+	defer cleaner2(t)
+
+	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, prvExt, pubExt)
+	assert.NoError(t, err)
+
+	const prvExt2 = "v"
+	const pubExt2 = "b"
+
+	err = ExportKeyStore(kStore, tempDir2, prvExt2, pubExt2)
+	assert.NoError(t, err)
+
+	kStore2, err := NewMJwtKeyStoreFromDirectory(tempDir2, prvExt2, pubExt2)
+	assert.NoError(t, err)
+
+	kIDsToFind := kStore.ListKeys()
+	assert.Len(t, kStore2.ListKeys(), len(kIDsToFind))
+	for _, k := range kIDsToFind {
+		assert.Contains(t, kStore2.ListKeys(), k)
+	}
+
+	commonSubTests(t, kStore2)
 }

--- a/key_store_test.go
+++ b/key_store_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 )
 
-const prvExt = "prv"
-const pubExt = "pub"
+const kst_prvExt = "prv"
+const kst_pubExt = "pub"
 
 func setupTestDirKeyStore(t *testing.T, genKeys bool) (string, func(t *testing.T)) {
 	tempDir, err := os.MkdirTemp("", "this-is-a-test-dir")
@@ -21,19 +21,19 @@ func setupTestDirKeyStore(t *testing.T, genKeys bool) (string, func(t *testing.T
 	if genKeys {
 		key1, err := rsa.GenerateKey(rand.Reader, 2048)
 		assert.NoError(t, err)
-		err = rsaprivate.Write(path.Join(tempDir, "key1.pem."+prvExt), key1)
+		err = rsaprivate.Write(path.Join(tempDir, "key1.pem."+kst_prvExt), key1)
 		assert.NoError(t, err)
 
 		key2, err := rsa.GenerateKey(rand.Reader, 2048)
 		assert.NoError(t, err)
-		err = rsaprivate.Write(path.Join(tempDir, "key2.pem."+prvExt), key2)
+		err = rsaprivate.Write(path.Join(tempDir, "key2.pem."+kst_prvExt), key2)
 		assert.NoError(t, err)
-		err = rsapublic.Write(path.Join(tempDir, "key2.pem."+pubExt), &key2.PublicKey)
+		err = rsapublic.Write(path.Join(tempDir, "key2.pem."+kst_pubExt), &key2.PublicKey)
 		assert.NoError(t, err)
 
 		key3, err := rsa.GenerateKey(rand.Reader, 2048)
 		assert.NoError(t, err)
-		err = rsapublic.Write(path.Join(tempDir, "key3.pem."+pubExt), &key3.PublicKey)
+		err = rsapublic.Write(path.Join(tempDir, "key3.pem."+kst_pubExt), &key3.PublicKey)
 		assert.NoError(t, err)
 	}
 
@@ -110,7 +110,7 @@ func TestNewMJwtKeyStoreFromDirectory(t *testing.T) {
 	tempDir, cleaner := setupTestDirKeyStore(t, true)
 	defer cleaner(t)
 
-	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, prvExt, pubExt)
+	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, kst_prvExt, kst_pubExt)
 	assert.NoError(t, err)
 
 	assert.Len(t, kStore.ListKeys(), 3)
@@ -130,7 +130,7 @@ func TestExportKeyStore(t *testing.T) {
 	tempDir2, cleaner2 := setupTestDirKeyStore(t, false)
 	defer cleaner2(t)
 
-	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, prvExt, pubExt)
+	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, kst_prvExt, kst_pubExt)
 	assert.NoError(t, err)
 
 	const prvExt2 = "v"

--- a/key_store_test.go
+++ b/key_store_test.go
@@ -14,7 +14,7 @@ import (
 const prvExt = "prv"
 const pubExt = "pub"
 
-func setupTestDir(t *testing.T, genKeys bool) (string, func(t *testing.T)) {
+func setupTestDirKeyStore(t *testing.T, genKeys bool) (string, func(t *testing.T)) {
 	tempDir, err := os.MkdirTemp("", "this-is-a-test-dir")
 	assert.NoError(t, err)
 
@@ -43,7 +43,7 @@ func setupTestDir(t *testing.T, genKeys bool) (string, func(t *testing.T)) {
 	}
 }
 
-func commonSubTests(t *testing.T, kStore KeyStore) {
+func commonSubTestsKeyStore(t *testing.T, kStore KeyStore) {
 	key4, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.NoError(t, err)
 
@@ -54,14 +54,12 @@ func commonSubTests(t *testing.T, kStore KeyStore) {
 	const extraKID2 = "key5"
 
 	t.Run("TestSetKey", func(t *testing.T) {
-		b := kStore.SetKey(extraKID1, key4)
-		assert.True(t, b)
+		kStore.SetKey(extraKID1, key4)
 		assert.Contains(t, kStore.ListKeys(), extraKID1)
 	})
 
 	t.Run("TestSetKeyPublic", func(t *testing.T) {
-		b := kStore.SetKeyPublic(extraKID2, &key5.PublicKey)
-		assert.True(t, b)
+		kStore.SetKeyPublic(extraKID2, &key5.PublicKey)
 		assert.Contains(t, kStore.ListKeys(), extraKID2)
 	})
 
@@ -109,7 +107,7 @@ func commonSubTests(t *testing.T, kStore KeyStore) {
 func TestNewMJwtKeyStoreFromDirectory(t *testing.T) {
 	t.Parallel()
 
-	tempDir, cleaner := setupTestDir(t, true)
+	tempDir, cleaner := setupTestDirKeyStore(t, true)
 	defer cleaner(t)
 
 	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, prvExt, pubExt)
@@ -121,15 +119,15 @@ func TestNewMJwtKeyStoreFromDirectory(t *testing.T) {
 		assert.Contains(t, kStore.ListKeys(), k)
 	}
 
-	commonSubTests(t, kStore)
+	commonSubTestsKeyStore(t, kStore)
 }
 
 func TestExportKeyStore(t *testing.T) {
 	t.Parallel()
 
-	tempDir, cleaner := setupTestDir(t, true)
+	tempDir, cleaner := setupTestDirKeyStore(t, true)
 	defer cleaner(t)
-	tempDir2, cleaner2 := setupTestDir(t, false)
+	tempDir2, cleaner2 := setupTestDirKeyStore(t, false)
 	defer cleaner2(t)
 
 	kStore, err := NewMJwtKeyStoreFromDirectory(tempDir, prvExt, pubExt)
@@ -150,5 +148,5 @@ func TestExportKeyStore(t *testing.T) {
 		assert.Contains(t, kStore2.ListKeys(), k)
 	}
 
-	commonSubTests(t, kStore2)
+	commonSubTestsKeyStore(t, kStore2)
 }

--- a/mjwt_test.go
+++ b/mjwt_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+var mt_ExtraKID = "tester"
+
 type testClaims struct{ TestValue string }
 
 func (t testClaims) Valid() error {
@@ -31,31 +33,111 @@ func (t testClaims2) Valid() error {
 
 func (t testClaims2) Type() string { return "testClaims2" }
 
+func setupTestKeyStoreMJWT(t *testing.T) (ks KeyStore, a, b, c *rsa.PrivateKey) {
+	ks = NewMJwtKeyStore()
+	var err error
+
+	a, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	ks.SetKey("key1", a)
+
+	b, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	ks.SetKey("key2", b)
+
+	c, err = rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	ks.SetKey("key3", c)
+
+	return
+}
+
 func TestExtractClaims(t *testing.T) {
 	t.Parallel()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(t, err)
+	kStore, key, _, _ := setupTestKeyStoreMJWT(t)
 
-	s := NewMJwtSigner("mjwt.test", key)
-	token, err := s.GenerateJwt("1", "test", nil, 10*time.Minute, testClaims{TestValue: "hello"})
-	assert.NoError(t, err)
+	t.Run("TestNoKID", func(t *testing.T) {
+		t.Parallel()
+		s := NewMJwtSigner("mjwt.test", key)
+		token, err := s.GenerateJwt("1", "test", nil, 10*time.Minute, testClaims{TestValue: "hello"})
+		assert.NoError(t, err)
 
-	m := NewMJwtVerifier(&key.PublicKey)
-	_, _, err = ExtractClaims[testClaims](m, token)
-	assert.NoError(t, err)
+		m := NewMJwtVerifier(&key.PublicKey)
+		_, _, err = ExtractClaims[testClaims](m, token)
+		assert.NoError(t, err)
+	})
+
+	t.Run("TestKID", func(t *testing.T) {
+		t.Parallel()
+		s := NewMJwtSignerWithKeyStore("mjwt.test", key, kStore)
+		token1, err := s.GenerateJwt("1", "test", nil, 10*time.Minute, testClaims{TestValue: "hello"})
+		assert.NoError(t, err)
+		token2, err := s.GenerateJwtWithKID("1", "test", nil, 10*time.Minute, testClaims{TestValue: "hello"}, "key2")
+		assert.NoError(t, err)
+
+		m := NewMJwtVerifierWithKeyStore(&key.PublicKey, kStore)
+		_, _, err = ExtractClaims[testClaims](m, token1)
+		assert.NoError(t, err)
+		_, _, err = ExtractClaims[testClaims](m, token2)
+		assert.NoError(t, err)
+	})
 }
 
 func TestExtractClaimsFail(t *testing.T) {
 	t.Parallel()
-	key, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(t, err)
+	kStore, key, key2, _ := setupTestKeyStoreMJWT(t)
 
-	s := NewMJwtSigner("mjwt.test", key)
-	token, err := s.GenerateJwt("1", "test", nil, 10*time.Minute, testClaims{TestValue: "test"})
-	assert.NoError(t, err)
+	t.Run("TestInvalidClaims", func(t *testing.T) {
+		t.Parallel()
+		s := NewMJwtSigner("mjwt.test", key)
+		token, err := s.GenerateJwt("1", "test", nil, 10*time.Minute, testClaims{TestValue: "test"})
+		assert.NoError(t, err)
 
-	m := NewMJwtVerifier(&key.PublicKey)
-	_, _, err = ExtractClaims[testClaims2](m, token)
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, ErrClaimTypeMismatch)
+		m := NewMJwtVerifier(&key.PublicKey)
+		_, _, err = ExtractClaims[testClaims2](m, token)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrClaimTypeMismatch)
+	})
+
+	t.Run("TestDefaultKeyNoKID", func(t *testing.T) {
+		t.Parallel()
+		s := NewMJwtSignerWithKeyStore("mjwt.test", key, kStore)
+		token, err := s.GenerateJwtWithKID("1", "test", nil, 10*time.Minute, testClaims{TestValue: "test"}, "key1")
+		assert.NoError(t, err)
+
+		m := NewMJwtVerifier(&key.PublicKey)
+		_, _, err = ExtractClaims[testClaims](m, token)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoPublicKeyFound)
+	})
+
+	t.Run("TestNoDefaultKey", func(t *testing.T) {
+		t.Parallel()
+		s := NewMJwtSignerWithKeyStore("mjwt.test", key, kStore)
+		token, err := s.GenerateJwt("1", "test", nil, 10*time.Minute, testClaims{TestValue: "test"})
+		assert.NoError(t, err)
+
+		m := NewMJwtVerifierWithKeyStore(nil, kStore)
+		_, _, err = ExtractClaims[testClaims](m, token)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoPublicKeyFound)
+	})
+
+	t.Run("TestKIDNonExist", func(t *testing.T) {
+		t.Parallel()
+		kStore.SetKey(mt_ExtraKID, key2)
+		assert.Contains(t, kStore.ListKeys(), mt_ExtraKID)
+
+		s := NewMJwtSignerWithKeyStore("mjwt.test", key, kStore)
+		token, err := s.GenerateJwtWithKID("1", "test", nil, 10*time.Minute, testClaims{TestValue: "test"}, mt_ExtraKID)
+		assert.NoError(t, err)
+
+		kStore.RemoveKey(mt_ExtraKID)
+		assert.NotContains(t, kStore.ListKeys(), mt_ExtraKID)
+
+		m := NewMJwtVerifierWithKeyStore(&key.PublicKey, kStore)
+		_, _, err = ExtractClaims[testClaims](m, token)
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoPublicKeyFound)
+	})
 }

--- a/signer.go
+++ b/signer.go
@@ -12,7 +12,6 @@ import (
 )
 
 var ErrNoPrivateKeyFound = errors.New("no private key found")
-var ErrSignerNil = errors.New("signer nil")
 
 // defaultMJwtSigner implements Signer and uses an rsa.PrivateKey and issuer name
 // to generate MJWT tokens
@@ -95,26 +94,17 @@ func NewMJwtSignerFromFileAndDirectory(issuer, file, directory, prvExt, pubExt s
 
 // Issuer returns the name of the issuer
 func (d *defaultMJwtSigner) Issuer() string {
-	if d == nil {
-		return ""
-	}
 	return d.issuer
 }
 
 // GenerateJwt generates and returns a JWT string using the sub, id, duration and claims; uses the default key
 func (d *defaultMJwtSigner) GenerateJwt(sub, id string, aud jwt.ClaimStrings, dur time.Duration, claims Claims) (string, error) {
-	if d == nil {
-		return "", ErrSignerNil
-	}
 	return d.SignJwt(wrapClaims[Claims](d, sub, id, aud, dur, claims))
 }
 
 // SignJwt signs a jwt.Claims compatible struct, this is used internally by
 // GenerateJwt but is available for signing custom structs; uses the default key
 func (d *defaultMJwtSigner) SignJwt(wrapped jwt.Claims) (string, error) {
-	if d == nil {
-		return "", ErrSignerNil
-	}
 	if d.key == nil {
 		return "", ErrNoPrivateKeyFound
 	}
@@ -124,18 +114,12 @@ func (d *defaultMJwtSigner) SignJwt(wrapped jwt.Claims) (string, error) {
 
 // GenerateJwtWithKID generates and returns a JWT string using the sub, id, duration and claims; this gets signed with the specified kID
 func (d *defaultMJwtSigner) GenerateJwtWithKID(sub, id string, aud jwt.ClaimStrings, dur time.Duration, claims Claims, kID string) (string, error) {
-	if d == nil {
-		return "", ErrSignerNil
-	}
 	return d.SignJwtWithKID(wrapClaims[Claims](d, sub, id, aud, dur, claims), kID)
 }
 
 // SignJwtWithKID signs a jwt.Claims compatible struct, this is used internally by
 // GenerateJwt but is available for signing custom structs; this gets signed with the specified kID
 func (d *defaultMJwtSigner) SignJwtWithKID(wrapped jwt.Claims, kID string) (string, error) {
-	if d == nil {
-		return "", ErrSignerNil
-	}
 	pKey := d.verify.GetKeyStore().GetKey(kID)
 	if pKey == nil {
 		return "", ErrNoPrivateKeyFound
@@ -147,43 +131,25 @@ func (d *defaultMJwtSigner) SignJwtWithKID(wrapped jwt.Claims, kID string) (stri
 
 // VerifyJwt validates and parses MJWT tokens see defaultMJwtVerifier.VerifyJwt()
 func (d *defaultMJwtSigner) VerifyJwt(token string, claims baseTypeClaim) (*jwt.Token, error) {
-	if d == nil {
-		return nil, ErrSignerNil
-	}
 	return d.verify.VerifyJwt(token, claims)
 }
 
 func (d *defaultMJwtSigner) PrivateKey() *rsa.PrivateKey {
-	if d == nil {
-		return nil
-	}
 	return d.key
 }
 func (d *defaultMJwtSigner) PublicKey() *rsa.PublicKey {
-	if d == nil {
-		return nil
-	}
 	return d.verify.pub
 }
 
 func (d *defaultMJwtSigner) PublicKeyOf(kID string) *rsa.PublicKey {
-	if d == nil {
-		return nil
-	}
 	return d.verify.kStore.GetKeyPublic(kID)
 }
 
 func (d *defaultMJwtSigner) GetKeyStore() KeyStore {
-	if d == nil {
-		return nil
-	}
 	return d.verify.GetKeyStore()
 }
 
 func (d *defaultMJwtSigner) PrivateKeyOf(kID string) *rsa.PrivateKey {
-	if d == nil {
-		return nil
-	}
 	return d.verify.kStore.GetKey(kID)
 }
 

--- a/signer_test.go
+++ b/signer_test.go
@@ -5,16 +5,63 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"github.com/1f349/rsa-helper/rsaprivate"
+	"github.com/1f349/rsa-helper/rsapublic"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"path"
 	"testing"
 )
+
+const st_prvExt = "prv"
+const st_pubExt = "pub"
+
+func setupTestDirSigner(t *testing.T, genKeys bool) (string, *rsa.PrivateKey, func(t *testing.T)) {
+	tempDir, err := os.MkdirTemp("", "this-is-a-test-dir")
+	assert.NoError(t, err)
+
+	var key3 *rsa.PrivateKey = nil
+
+	if genKeys {
+		key1, err := rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsaprivate.Write(path.Join(tempDir, "key1.pem."+st_prvExt), key1)
+		assert.NoError(t, err)
+
+		key2, err := rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsaprivate.Write(path.Join(tempDir, "key2.pem."+st_prvExt), key2)
+		assert.NoError(t, err)
+		err = rsapublic.Write(path.Join(tempDir, "key2.pem."+st_pubExt), &key2.PublicKey)
+		assert.NoError(t, err)
+
+		key3, err = rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsapublic.Write(path.Join(tempDir, "key3.pem."+st_pubExt), &key3.PublicKey)
+		assert.NoError(t, err)
+	}
+
+	return tempDir, key3, func(t *testing.T) {
+		err := os.RemoveAll(tempDir)
+		assert.NoError(t, err)
+	}
+}
 
 func TestNewMJwtSigner(t *testing.T) {
 	t.Parallel()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	assert.NoError(t, err)
 	NewMJwtSigner("Test", key)
+}
+
+func TestNewMJwtSignerWithKeyStore(t *testing.T) {
+	t.Parallel()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NoError(t, err)
+	kStore := NewMJwtKeyStore()
+	kStore.SetKey("test", key)
+	assert.Contains(t, kStore.ListKeys(), "test")
+	NewMJwtSignerWithKeyStore("Test", nil, kStore)
 }
 
 func TestNewMJwtSignerFromFile(t *testing.T) {
@@ -66,4 +113,39 @@ func TestReadOrCreatePrivateKey(t *testing.T) {
 	key3, err := readOrCreatePrivateKey(tempKey.Name(), rand.Reader, 2048)
 	assert.NoError(t, err)
 	assert.NoError(t, key3.Validate())
+}
+
+func TestNewMJwtSignerFromDirectory(t *testing.T) {
+	t.Parallel()
+
+	tempDir, prvKey3, cleaner := setupTestDirSigner(t, true)
+	defer cleaner(t)
+
+	signer, err := NewMJwtSignerFromDirectory("Test", tempDir, st_prvExt, st_pubExt)
+	assert.NoError(t, err)
+
+	assert.Len(t, signer.GetKeyStore().ListKeys(), 3)
+	kIDsToFind := []string{"key1", "key2", "key3"}
+	for _, k := range kIDsToFind {
+		assert.Contains(t, signer.GetKeyStore().ListKeys(), k)
+	}
+	assert.True(t, prvKey3.PublicKey.Equal(signer.GetKeyStore().GetKeyPublic("key3")))
+}
+
+func TestNewMJwtSignerFromFileAndDirectory(t *testing.T) {
+	t.Parallel()
+
+	tempDir, prvKey3, cleaner := setupTestDirSigner(t, true)
+	defer cleaner(t)
+
+	signer, err := NewMJwtSignerFromFileAndDirectory("Test", path.Join(tempDir, "key1.pem."+st_prvExt), tempDir, st_prvExt, st_pubExt)
+	assert.NoError(t, err)
+
+	assert.Len(t, signer.GetKeyStore().ListKeys(), 3)
+	kIDsToFind := []string{"key1", "key2", "key3"}
+	for _, k := range kIDsToFind {
+		assert.Contains(t, signer.GetKeyStore().ListKeys(), k)
+	}
+	assert.True(t, prvKey3.PublicKey.Equal(signer.GetKeyStore().GetKeyPublic("key3")))
+	assert.True(t, signer.PrivateKey().Equal(signer.GetKeyStore().GetKey("key1")))
 }

--- a/verifier.go
+++ b/verifier.go
@@ -2,6 +2,7 @@ package mjwt
 
 import (
 	"crypto/rsa"
+	"errors"
 	"github.com/1f349/rsa-helper/rsapublic"
 	"github.com/golang-jwt/jwt/v4"
 )
@@ -9,36 +10,84 @@ import (
 // defaultMJwtVerifier implements Verifier and uses a rsa.PublicKey to validate
 // MJWT tokens
 type defaultMJwtVerifier struct {
-	pub *rsa.PublicKey
+	pub    *rsa.PublicKey
+	kStore KeyStore
 }
 
 var _ Verifier = &defaultMJwtVerifier{}
 
 // NewMJwtVerifier creates a new defaultMJwtVerifier using the rsa.PublicKey
 func NewMJwtVerifier(key *rsa.PublicKey) Verifier {
-	return newMJwtVerifier(key)
+	return NewMjwtVerifierWithKeyStore(key, NewMJwtKeyStore())
 }
 
-func newMJwtVerifier(key *rsa.PublicKey) *defaultMJwtVerifier {
-	return &defaultMJwtVerifier{pub: key}
+// NewMjwtVerifierWithKeyStore creates a new defaultMJwtVerifier using a rsa.PublicKey as the non kID key
+// and a KeyStore for kID based keys
+func NewMjwtVerifierWithKeyStore(defaultKey *rsa.PublicKey, kStore KeyStore) Verifier {
+	return &defaultMJwtVerifier{pub: defaultKey, kStore: kStore}
 }
 
 // NewMJwtVerifierFromFile creates a new defaultMJwtVerifier using the path of a
 // rsa.PublicKey file
 func NewMJwtVerifierFromFile(file string) (Verifier, error) {
+	return NewMJwtVerifierFromFileAndDirectory(file, "", "", "")
+}
+
+// NewMJwtVerifierFromDirectory creates a new defaultMJwtVerifier using the path of a directory to
+// load the keys into a KeyStore; there is no default rsa.PublicKey
+func NewMJwtVerifierFromDirectory(directory, prvExt, pubExt string) (Verifier, error) {
+	return NewMJwtVerifierFromFileAndDirectory("", directory, prvExt, pubExt)
+}
+
+// NewMJwtVerifierFromFileAndDirectory creates a new defaultMJwtVerifier using the path of a rsa.PublicKey
+// file as the non kID key and the path of a directory to load the keys into a KeyStore
+func NewMJwtVerifierFromFileAndDirectory(file, directory, prvExt, pubExt string) (Verifier, error) {
+	var err error
+
 	// read key
-	pub, err := rsapublic.Read(file)
-	if err != nil {
-		return nil, err
+	var pub *rsa.PublicKey = nil
+	if file != "" {
+		pub, err = rsapublic.Read(file)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// create verifier using rsa.PublicKey
-	return NewMJwtVerifier(pub), nil
+	// read KeyStore
+	var kStore KeyStore = nil
+	if directory != "" {
+		kStore, err = NewMJwtKeyStoreFromDirectory(directory, prvExt, pubExt)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return NewMjwtVerifierWithKeyStore(pub, kStore), nil
 }
 
 // VerifyJwt validates and parses MJWT tokens and returns the claims
 func (d *defaultMJwtVerifier) VerifyJwt(token string, claims baseTypeClaim) (*jwt.Token, error) {
+	if d == nil {
+		return nil, errors.New("verifier nil")
+	}
 	withClaims, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
+		kIDI, exs := token.Header["kid"]
+		if exs {
+			kID, ok := kIDI.(string)
+			if ok {
+				key := d.kStore.GetKeyPublic(kID)
+				if key == nil {
+					return nil, errors.New("no public key found")
+				} else {
+					return key, nil
+				}
+			} else {
+				return nil, errors.New("kid invalid")
+			}
+		}
+		if d.pub == nil {
+			return nil, errors.New("no public key found")
+		}
 		return d.pub, nil
 	})
 	if err != nil {
@@ -47,4 +96,23 @@ func (d *defaultMJwtVerifier) VerifyJwt(token string, claims baseTypeClaim) (*jw
 	return withClaims, claims.Valid()
 }
 
-func (d *defaultMJwtVerifier) PublicKey() *rsa.PublicKey { return d.pub }
+func (d *defaultMJwtVerifier) PublicKey() *rsa.PublicKey {
+	if d == nil {
+		return nil
+	}
+	return d.pub
+}
+
+func (d *defaultMJwtVerifier) PublicKeyOf(kID string) *rsa.PublicKey {
+	if d == nil {
+		return nil
+	}
+	return d.kStore.GetKeyPublic(kID)
+}
+
+func (d *defaultMJwtVerifier) GetKeyStore() KeyStore {
+	if d == nil {
+		return nil
+	}
+	return d.kStore
+}

--- a/verifier.go
+++ b/verifier.go
@@ -78,15 +78,14 @@ func (d *defaultMJwtVerifier) VerifyJwt(token string, claims baseTypeClaim) (*jw
 		kIDI, exs := token.Header["kid"]
 		if exs {
 			kID, ok := kIDI.(string)
-			if ok {
-				key := d.kStore.GetKeyPublic(kID)
-				if key == nil {
-					return nil, ErrNoPublicKeyFound
-				} else {
-					return key, nil
-				}
-			} else {
+			if !ok {
 				return nil, ErrKIDInvalid
+			}
+			key := d.kStore.GetKeyPublic(kID)
+			if key == nil {
+				return nil, ErrNoPublicKeyFound
+			} else {
+				return key, nil
 			}
 		}
 		if d.pub == nil {

--- a/verifier.go
+++ b/verifier.go
@@ -9,7 +9,6 @@ import (
 
 var ErrNoPublicKeyFound = errors.New("no public key found")
 var ErrKIDInvalid = errors.New("kid invalid")
-var ErrVerifierNil = errors.New("verifier nil")
 
 // defaultMJwtVerifier implements Verifier and uses a rsa.PublicKey to validate
 // MJWT tokens
@@ -71,9 +70,6 @@ func NewMJwtVerifierFromFileAndDirectory(file, directory, prvExt, pubExt string)
 
 // VerifyJwt validates and parses MJWT tokens and returns the claims
 func (d *defaultMJwtVerifier) VerifyJwt(token string, claims baseTypeClaim) (*jwt.Token, error) {
-	if d == nil {
-		return nil, ErrVerifierNil
-	}
 	withClaims, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (interface{}, error) {
 		kIDI, exs := token.Header["kid"]
 		if exs {
@@ -100,22 +96,13 @@ func (d *defaultMJwtVerifier) VerifyJwt(token string, claims baseTypeClaim) (*jw
 }
 
 func (d *defaultMJwtVerifier) PublicKey() *rsa.PublicKey {
-	if d == nil {
-		return nil
-	}
 	return d.pub
 }
 
 func (d *defaultMJwtVerifier) PublicKeyOf(kID string) *rsa.PublicKey {
-	if d == nil {
-		return nil
-	}
 	return d.kStore.GetKeyPublic(kID)
 }
 
 func (d *defaultMJwtVerifier) GetKeyStore() KeyStore {
-	if d == nil {
-		return nil
-	}
 	return d.kStore
 }

--- a/verifier.go
+++ b/verifier.go
@@ -2,10 +2,8 @@ package mjwt
 
 import (
 	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
+	"github.com/1f349/rsa-helper/rsapublic"
 	"github.com/golang-jwt/jwt/v4"
-	"os"
 )
 
 // defaultMJwtVerifier implements Verifier and uses a rsa.PublicKey to validate
@@ -28,17 +26,8 @@ func newMJwtVerifier(key *rsa.PublicKey) *defaultMJwtVerifier {
 // NewMJwtVerifierFromFile creates a new defaultMJwtVerifier using the path of a
 // rsa.PublicKey file
 func NewMJwtVerifierFromFile(file string) (Verifier, error) {
-	// read file
-	f, err := os.ReadFile(file)
-	if err != nil {
-		return nil, err
-	}
-
-	// decode pem block
-	block, _ := pem.Decode(f)
-
-	// parse public key from pem block
-	pub, err := x509.ParsePKCS1PublicKey(block.Bytes)
+	// read key
+	pub, err := rsapublic.Read(file)
 	if err != nil {
 		return nil, err
 	}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -5,11 +5,48 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"github.com/1f349/rsa-helper/rsaprivate"
+	"github.com/1f349/rsa-helper/rsapublic"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"path"
 	"testing"
 	"time"
 )
+
+const vt_prvExt = "prv"
+const vt_pubExt = "pub"
+
+func setupTestDirVerifier(t *testing.T, genKeys bool) (string, *rsa.PrivateKey, func(t *testing.T)) {
+	tempDir, err := os.MkdirTemp("", "this-is-a-test-dir")
+	assert.NoError(t, err)
+
+	var key3 *rsa.PrivateKey = nil
+
+	if genKeys {
+		key1, err := rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsaprivate.Write(path.Join(tempDir, "key1.pem."+vt_prvExt), key1)
+		assert.NoError(t, err)
+
+		key2, err := rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsaprivate.Write(path.Join(tempDir, "key2.pem."+vt_prvExt), key2)
+		assert.NoError(t, err)
+		err = rsapublic.Write(path.Join(tempDir, "key2.pem."+vt_pubExt), &key2.PublicKey)
+		assert.NoError(t, err)
+
+		key3, err = rsa.GenerateKey(rand.Reader, 2048)
+		assert.NoError(t, err)
+		err = rsapublic.Write(path.Join(tempDir, "key3.pem."+vt_pubExt), &key3.PublicKey)
+		assert.NoError(t, err)
+	}
+
+	return tempDir, key3, func(t *testing.T) {
+		err := os.RemoveAll(tempDir)
+		assert.NoError(t, err)
+	}
+}
 
 func TestNewMJwtVerifierFromFile(t *testing.T) {
 	t.Parallel()
@@ -30,5 +67,45 @@ func TestNewMJwtVerifierFromFile(t *testing.T) {
 	_, _, err = ExtractClaims[testClaims](file, token)
 	assert.NoError(t, err)
 	err = os.Remove(temp.Name())
+	assert.NoError(t, err)
+}
+
+func TestNewMJwtVerifierFromDirectory(t *testing.T) {
+	t.Parallel()
+
+	tempDir, prvKey3, cleaner := setupTestDirVerifier(t, true)
+	defer cleaner(t)
+
+	s, err := NewMJwtSignerFromDirectory("mjwt.test", tempDir, vt_prvExt, vt_pubExt)
+	assert.NoError(t, err)
+	s.GetKeyStore().SetKey("key3", prvKey3)
+	token, err := s.GenerateJwtWithKID("1", "test", nil, 10*time.Minute, testClaims{TestValue: "world"}, "key3")
+	assert.NoError(t, err)
+
+	v, err := NewMJwtVerifierFromDirectory(tempDir, vt_prvExt, vt_pubExt)
+	assert.NoError(t, err)
+	_, _, err = ExtractClaims[testClaims](v, token)
+	assert.NoError(t, err)
+}
+
+func TestNewMJwtVerifierFromFileAndDirectory(t *testing.T) {
+	t.Parallel()
+
+	tempDir, prvKey3, cleaner := setupTestDirVerifier(t, true)
+	defer cleaner(t)
+
+	s, err := NewMJwtSignerFromFileAndDirectory("mjwt.test", path.Join(tempDir, "key2.pem."+vt_prvExt), tempDir, vt_prvExt, vt_pubExt)
+	assert.NoError(t, err)
+	s.GetKeyStore().SetKey("key3", prvKey3)
+	token1, err := s.GenerateJwt("1", "test", nil, 10*time.Minute, testClaims{TestValue: "world"})
+	assert.NoError(t, err)
+	token2, err := s.GenerateJwtWithKID("1", "test", nil, 10*time.Minute, testClaims{TestValue: "world"}, "key3")
+	assert.NoError(t, err)
+
+	v, err := NewMJwtVerifierFromFileAndDirectory(path.Join(tempDir, "key2.pem."+vt_pubExt), tempDir, vt_prvExt, vt_pubExt)
+	assert.NoError(t, err)
+	_, _, err = ExtractClaims[testClaims](v, token1)
+	assert.NoError(t, err)
+	_, _, err = ExtractClaims[testClaims](v, token2)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
This pull request implements kid support for multiple keys being possible on a back-end.
The kid is stored in the header portion and allows for the selection of the key known by the ID provided.
If no ID is provided, the stored 'default' key is used instead.

This closes #1 